### PR TITLE
Requirements are missing a dependancy stopping the UI from loading

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ pytz==2016.10
 structlog==16.1.0
 termcolor==1.1.0
 WTForms==2.1
-stripe
+stripe=2.21.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ pytz==2016.10
 structlog==16.1.0
 termcolor==1.1.0
 WTForms==2.1
+stripe


### PR DESCRIPTION
I added the latest version of stripe 2.21.0 to the requirements folder, which I have tested locally. 

The docker-compose loads successfully now.